### PR TITLE
Forwards compatibility with zend-servicemanager v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,19 +11,40 @@ cache:
   directories:
     - $HOME/.composer/cache
 
+env:
+  global:
+    - SERVICE_MANAGER_VERSION="^3.0.3"
+    - REMOVE_DEPENDENCIES="zendframework/zend-mvc"
+
 matrix:
   fast_finish: true
   include:
     - php: 5.5
       env:
         - EXECUTE_CS_CHECK=true
+    - php: 5.5
+      env:
+        - SERVICE_MANAGER_VERSION="^2.7.5"
+        - REMOVE_DEPENDENCIES=""
     - php: 5.6
       env:
         - EXECUTE_TEST_COVERALLS=true
+    - php: 5.6
+      env:
+        - SERVICE_MANAGER_VERSION="^2.7.5"
+        - REMOVE_DEPENDENCIES=""
     - php: 7
+    - php: 7
+      env:
+        - SERVICE_MANAGER_VERSION="^2.7.5"
+        - REMOVE_DEPENDENCIES=""
     - php: hhvm 
+    - php: hhvm 
+      env:
+        - SERVICE_MANAGER_VERSION="^2.7.5"
+        - REMOVE_DEPENDENCIES=""
   allow_failures:
-    - php: 7
+    - php: hhvm
 
 notifications:
   irc: "irc.freenode.org#zftalk.dev"
@@ -33,6 +54,8 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - composer self-update
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
+  - composer require --dev --no-update "zendframework/zend-servicemanager:$SERVICE_MANAGER_VERSION"
+  - if [[ $REMOVE_DEPENDENCIES != '' ]]; then composer remove --dev --no-update $REMOVE_DEPENDENCIES ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/composer.json
+++ b/composer.json
@@ -13,21 +13,20 @@
         }
     },
     "require": {
-        "php": ">=5.5",
-        "zendframework/zend-stdlib": "dev-develop as 2.8.0"
+        "php": "^5.5 || ^7.0",
+        "zendframework/zend-stdlib": "^2.7 || ^3.0"
     },
     "require-dev": {
-        "zendframework/zend-config": "dev-develop as 2.6.0",
-        "zendframework/zend-console": "~2.5",
-        "zendframework/zend-http": "~2.5",
-        "zendframework/zend-i18n": "dev-develop as 2.6.0",
-        "zendframework/zend-log": "~2.5",
-        "zendframework/zend-modulemanager": "dev-develop as 2.7.0",
-        "zendframework/zend-mvc": "dev-develop as 2.7.0",
-        "zendframework/zend-permissions-acl": "~2.5",
-        "zendframework/zend-servicemanager": "dev-develop as 2.7.0",
-        "zendframework/zend-uri": "~2.5",
-        "zendframework/zend-view": "dev-develop as 2.6.0",
+        "zendframework/zend-config": "^2.6",
+        "zendframework/zend-console": "^2.6",
+        "zendframework/zend-http": "^2.5.4",
+        "zendframework/zend-i18n": "^2.6",
+        "zendframework/zend-log": "^2.7.1",
+        "zendframework/zend-mvc": "^2.6.3",
+        "zendframework/zend-permissions-acl": "^2.6",
+        "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
+        "zendframework/zend-uri": "^2.5",
+        "zendframework/zend-view": "^2.6.3",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
     },

--- a/src/Service/AbstractNavigationFactory.php
+++ b/src/Service/AbstractNavigationFactory.php
@@ -16,7 +16,8 @@ use Zend\Mvc\Router\RouteMatch;
 use Zend\Mvc\Router\RouteStackInterface as Router;
 use Zend\Navigation\Exception;
 use Zend\Navigation\Navigation;
-use Zend\ServiceManager\Factory\FactoryInterface;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
 /**
  * Abstract navigation factory
@@ -29,12 +30,29 @@ abstract class AbstractNavigationFactory implements FactoryInterface
     protected $pages;
 
     /**
+     * Create and return a new Navigation instance (v3).
+     *
      * @param ContainerInterface $container
-     * @return \Zend\Navigation\Navigation
+     * @param string $requestedName
+     * @param null|array $options
+     * @return Navigation
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
         return new Navigation($this->getPages($container));
+    }
+
+    /**
+     * Create and return a new Navigation instance (v2).
+     *
+     * @param ContainerInterface $container
+     * @param null|string $name
+     * @param null|string $requestedName
+     * @return Navigation
+     */
+    public function createService(ServiceLocatorInterface $container, $name = null, $requestedName = null)
+    {
+        return $this($container, $requestedName);
     }
 
     /**

--- a/src/Service/NavigationAbstractServiceFactory.php
+++ b/src/Service/NavigationAbstractServiceFactory.php
@@ -11,7 +11,8 @@ namespace Zend\Navigation\Service;
 
 use Interop\Container\ContainerInterface;
 use Zend\Navigation\Navigation;
-use Zend\ServiceManager\Factory\AbstractFactoryInterface;
+use Zend\ServiceManager\AbstractFactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
 /**
  * Navigation abstract service factory
@@ -43,13 +44,14 @@ final class NavigationAbstractServiceFactory implements AbstractFactoryInterface
     protected $config;
 
     /**
-     * Can we create a navigation by the requested name?
+     * Can we create a navigation by the requested name? (v3)
      *
      * @param ContainerInterface $container
-     * @param string $requestedName Name by which service was requested, must start with Zend\Navigation\
+     * @param string $requestedName Name by which service was requested, must
+     *     start with Zend\Navigation\
      * @return bool
      */
-    public function canCreateServiceWithName(ContainerInterface $container, $requestedName)
+    public function canCreate(ContainerInterface $container, $requestedName)
     {
         if (0 !== strpos($requestedName, self::SERVICE_PREFIX)) {
             return false;
@@ -60,13 +62,45 @@ final class NavigationAbstractServiceFactory implements AbstractFactoryInterface
     }
 
     /**
+     * Can we create a navigation by the requested name? (v2)
+     *
+     * @param ServiceLocatorInterface $container
+     * @param string $name Normalized name by which service was requested;
+     *     ignored.
+     * @param string $requestedName Name by which service was requested, must
+     *     start with Zend\Navigation\
+     * @return bool
+     */
+    public function canCreateServiceWithName(ServiceLocatorInterface $container, $name, $requestedName)
+    {
+        return $this->canCreate($container, $requestedName);
+    }
+
+    /**
      * {@inheritDoc}
+     *
+     * @return Navigation
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
         $config  = $this->getConfig($container);
         $factory = new ConstructedNavigationFactory($this->getNamedConfig($requestedName, $config));
         return $factory($container, $requestedName);
+    }
+
+    /**
+     * Can we create a navigation by the requested name? (v2)
+     *
+     * @param ServiceLocatorInterface $container
+     * @param string $name Normalized name by which service was requested;
+     *     ignored.
+     * @param string $requestedName Name by which service was requested, must
+     *     start with Zend\Navigation\
+     * @return Navigation
+     */
+    public function createServiceWithName(ServiceLocatorInterface $container, $name, $requestedName)
+    {
+        return $this($container, $requestedName);
     }
 
     /**

--- a/src/View/HelperConfig.php
+++ b/src/View/HelperConfig.php
@@ -2,16 +2,17 @@
 /**
  * Zend Framework (http://framework.zend.com/)
  *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @link      http://github.com/zendframework/zend-navigation for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
 namespace Zend\Navigation\View;
 
-use Interop\Container\ContainerInterface;
+use ReflectionProperty;
+use Traversable;
 use Zend\ServiceManager\Config;
-use Zend\ServiceManager\ConfigInterface;
+use Zend\ServiceManager\Factory\InvokableFactory;
 use Zend\ServiceManager\ServiceManager;
 use Zend\Stdlib\ArrayUtils;
 use Zend\View\Helper\Navigation as NavigationHelper;
@@ -19,59 +20,268 @@ use Zend\View\Helper\Navigation as NavigationHelper;
 /**
  * Service manager configuration for navigation view helpers
  */
-class HelperConfig implements ConfigInterface
+class HelperConfig extends Config
 {
     /**
-     * Configure the provided service manager instance with the configuration
-     * in this class.
+     * Default configuration to apply.
      *
-     * Simply adds a factory for the navigation helper, and has it inject the helper
-     * with the service locator instance.
+     * @var string[][]
+     */
+    protected $config = [
+        'abstract_factories' => [],
+        'aliases' => [
+            'navigation' => NavigationHelper::class,
+            'Navigation' => NavigationHelper::class,
+        ],
+        'delegators' => [],
+        'factories' => [
+            NavigationHelper::class    => NavigationHelperFactory::class,
+            'zendviewhelpernavigation' => NavigationHelperFactory::class,
+        ],
+        'initializers'  => [],
+        'invokables'    => [],
+        'lazy_services' => [],
+        'services'      => [],
+        'shared'        => [],
+    ];
+
+    /**
+     * Navigation helper delegator factory.
+     *
+     * @var callable
+     */
+    protected $navigationDelegatorFactory;
+
+    /**
+     * Constructor.
+     *
+     * Ensure incoming configuration is *merged* with the defaults defined.
+     *
+     * @param array
+     */
+    public function __construct(array $config = [])
+    {
+        $this->mergeConfig($config);
+    }
+
+    /**
+     * Configure the provided container.
+     *
+     * Merges navigation_helpers configuration from the parent containers
+     * config service with the configuration in this class, and uses that to
+     * configure the provided service container (which should be the zend-view
+     * `HelperPluginManager`).  with the service locator instance.
+     *
+     * Before configuring he provided container, it also adds a delegator
+     * factory for the `Navigation` helper; the delegator uses the configuration
+     * from this class to seed the `PluginManager` used by the `NavigationHelper`,
+     * ensuring that any overrides provided via configuration are propagated
+     * to it.
      *
      * @param  ServiceManager $serviceManager
      * @return ServiceManager
      */
     public function configureServiceManager(ServiceManager $container)
     {
-        $helperConfig = $this->toArray();
-        if ($container->has('config')) {
-            $helperConfig = ArrayUtils::merge($helperConfig, $this->getConfiguredHelpers($container));
+        $services = $this->getParentContainer($container);
+
+        if ($services->has('config')) {
+            $this->mergeHelpersFromConfiguration($services->get('config'));
         }
-        return $container->withConfig($helperConfig);
+
+        $this->injectNavigationDelegatorFactory(method_exists($container, 'configure'));
+
+        parent::configureServiceManager($container);
+
+        return $container;
     }
 
     /**
-     * {@inheritDoc}
-     */
-    public function toArray()
-    {
-        return [
-            'aliases'   => [
-                'navigation' => 'Navigation',
-            ],
-            'factories' => [
-                'Navigation' => function (ContainerInterface $container) {
-                    $helper = new NavigationHelper();
-                    $helper->setServiceLocator($container);
-                    return $helper;
-                }
-            ]
-        ];
-    }
-
-    /**
-     * Get navigation view helper service configuration.
+     * Merge an array of configuration with the settings already present.
      *
-     * @param ContainerInterface $container
-     * @return array
+     * Processes invokables as invokable factories and optionally additional
+     * aliases.
+     *
+     * @param array $config
+     * @return void
      */
-    private function getConfiguredHelpers(ContainerInterface $container)
+    private function mergeConfig(array $config)
     {
-        $config = $container->get('config');
-        if (! isset($config['navigation_helpers'])) {
-            return [];
+        if (isset($config['invokables'])) {
+            $config = $this->processInvokables($config['invokables'], $config);
         }
 
-        return (new Config($config['navigation_helpers']))->toArray();
+        foreach ($config as $type => $services) {
+            if (isset($this->config[$type])) {
+                $this->config[$type] = ArrayUtils::merge($this->config[$type], $services);
+            }
+        }
+    }
+
+    /**
+     * Merge navigation helper configuration with default configuration.
+     *
+     * @param array|Traversable $config
+     * @return void
+     */
+    private function mergeHelpersFromConfiguration($config)
+    {
+        if ($config instanceof Traversable) {
+            $config = iterator_to_array($config);
+        }
+
+        if (! isset($config['navigation_helpers'])
+            || (! is_array($config['navigation_helpers']) && ! $config['navigation_helpers'] instanceof Traversable)
+        ) {
+            return;
+        }
+
+        $this->mergeConfig($config['navigation_helpers']);
+    }
+
+    /**
+     * Retrieve the parent container from the plugin manager, if possible.
+     *
+     * @param ServiceManager $container
+     * @return ServiceManager
+     */
+    private function getParentContainer(ServiceManager $container)
+    {
+        // We need the parent container in order to retrieve the config
+        // service. We should likely revisit how this is done in the future.
+        //
+        // v3:
+        if (method_exists($container, 'configure')) {
+            $r = new ReflectionProperty($container, 'creationContext');
+            $r->setAccessible(true);
+            return $r->getValue($container) ?: $container;
+        }
+
+        // v2:
+        return $container->getServiceLocator() ?: $container;
+    }
+
+    /**
+     * Normalizes a factory service name for use with zend-servicemanager v2.
+     *
+     * @param string $name
+     * @return string
+     */
+    private function normalizeNameForV2($name)
+    {
+        return strtolower(strtr($name, ['-' => '', '_' => '', ' ' => '', '\\' => '', '/' => '']));
+    }
+
+    /**
+     * Process invokables in order to seed aliases and factories.
+     *
+     * @param array $invokables Array of invokables defined
+     * @param array $config All service configuration
+     * @return array Array of all service configuration
+     */
+    private function processInvokables(array $invokables, array $config)
+    {
+        if (! isset($config['aliases'])) {
+            $config['aliases'] = [];
+        }
+
+        if (! isset($config['factories'])) {
+            $config['factories'] = [];
+        }
+
+        foreach ($invokables as $name => $class) {
+            $config['factories'][$class] = InvokableFactory::class;
+            $config['factories'][$this->normalizeNameForV2($class)] = InvokableFactory::class;
+
+            if ($name === $class) {
+                continue;
+            }
+
+            $config['aliases'][$name] = $class;
+        }
+
+        unset($config['invokables']);
+
+        return $config;
+    }
+
+    /**
+     * Inject the navigation helper delegator factory into the configuration.
+     *
+     * @param bool $isV3Container
+     * @return void
+     */
+    private function injectNavigationDelegatorFactory($isV3Container)
+    {
+        $factory = $this->prepareNavigationDelegatorFactory($isV3Container);
+
+        if (isset($this->config['delegators'][NavigationHelperFactory::class])
+            && in_array($factory, $this->config['delegators'][NavigationHelperFactory::class], true)
+        ) {
+            // Already present
+            return;
+        }
+
+        // Inject the delegator factory
+        $this->config['delegators'][NavigationHelper::class][] = $factory;
+        $this->config['delegators']['zendviewhelpernavigation'][] = $factory;
+    }
+
+    /**
+     * Return a delegator factory that configures the navigation plugin manager
+     * with the configuration in this class.
+     *
+     * @param bool $isV3Container
+     * @return callable
+     */
+    private function prepareNavigationDelegatorFactory($isV3Container)
+    {
+        if (isset($this->navigationDelegatorFactory)) {
+            return $this->navigationDelegatorFactory;
+        }
+
+        $this->navigationDelegatorFactory = $isV3Container
+            ? $this->prepareV3NavigationDelegatorFactory($this->config)
+            : $this->prepareV2NavigationDelegatorFactory($this->config);
+
+        return $this->navigationDelegatorFactory;
+    }
+
+    /**
+     * Return a delegator factory compatible with v2
+     *
+     * @param array $config Configuration to use when configuring the
+     *     navigation plugin manager.
+     * @return callable
+     */
+    private function prepareV2NavigationDelegatorFactory(array $config)
+    {
+        return function ($container, $canonicalName, $requestedName, $callback) use ($config) {
+            $helper = $callback();
+
+            $pluginManager = $helper->getPluginManager();
+            (new Config($config))->configureServiceManager($pluginManager);
+
+            return $helper;
+        };
+    }
+
+    /**
+     * Return a delegator factory compatible with v3
+     *
+     * @param array $config Configuration to use when configuring the
+     *     navigation plugin manager.
+     * @return callable
+     */
+    private function prepareV3NavigationDelegatorFactory(array $config)
+    {
+        return function ($container, $name, $callback, $options) use ($config) {
+            $helper = $callback();
+
+            $pluginManager = $helper->getPluginManager();
+            (new Config($config))->configureServiceManager($pluginManager);
+
+            return $helper;
+        };
     }
 }

--- a/src/View/NavigationHelperFactory.php
+++ b/src/View/NavigationHelperFactory.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zend-navigation for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Navigation\View;
+
+use Interop\Container\ContainerInterface;
+use ReflectionProperty;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\View\Helper\Navigation as NavigationHelper;
+
+class NavigationHelperFactory implements FactoryInterface
+{
+    /**
+     * Create and return a navigation helper instance. (v3)
+     *
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param null|array $options
+     * @return NavigationHelper
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    {
+        $helper = new NavigationHelper();
+        $helper->setServiceLocator($this->getApplicationServicesFromContainer($container));
+        return $helper;
+    }
+
+    /**
+     * Create and return a navigation helper instance. (v2)
+     *
+     * @param ServiceLocatorInterface $container
+     * @param null|string $name
+     * @param string $requestedName
+     * @return NavigationHelper
+     */
+    public function createService(
+        ServiceLocatorInterface $container,
+        $name = null,
+        $requestedName = NavigationHelper::class
+    ) {
+        return $this($container, $requestedName);
+    }
+
+    /**
+     * Retrieve the application (parent) services from the container, if possible.
+     *
+     * @param ContainerInterface $container
+     * @return ContainerInterface
+     */
+    private function getApplicationServicesFromContainer(ContainerInterface $container)
+    {
+        // v3
+        if (method_exists($container, 'configure')) {
+            $r = new ReflectionProperty($container, 'creationContext');
+            $r->setAccessible(true);
+            return $r->getValue($container) ?: $container;
+        }
+
+        // v2
+        return $container->getServiceLocator() ?: $container;
+    }
+}

--- a/test/Page/MvcTest.php
+++ b/test/Page/MvcTest.php
@@ -30,6 +30,13 @@ class MvcTest extends TestCase
 {
     protected function setUp()
     {
+        if (! class_exists(RouteMatch::class)) {
+            $this->markTestSkipped(
+                'Skipping zend-mvc-related tests until that component is updated '
+                . 'to zend-servicemanager v3'
+            );
+        }
+
         $this->route  = new RegexRoute(
             '((?<controller>[^/]+)(/(?<action>[^/]+))?)',
             '/%controller%/%action%',

--- a/test/View/HelperConfigTest.php
+++ b/test/View/HelperConfigTest.php
@@ -12,8 +12,10 @@ namespace ZendTest\Navigation\View;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Navigation\Service\DefaultNavigationFactory;
 use Zend\Navigation\View\HelperConfig;
+use Zend\ServiceManager\Config;
 use Zend\ServiceManager\ServiceManager;
 use Zend\View\HelperPluginManager;
+use Zend\View\Helper\Navigation as NavigationHelper;
 
 /**
  * Tests the class Zend_Navigation_Page_Mvc
@@ -22,13 +24,25 @@ use Zend\View\HelperPluginManager;
  */
 class HelperConfigTest extends TestCase
 {
-    public function testConfigureServiceManagerWithConfig()
+    public function navigationServiceNameProvider()
     {
-        $this->markTestIncomplete('Waiting on changes to zend-view Helper\\Navigation\\PluginManager');
+        return [
+            ['navigation'],
+            ['Navigation'],
+            [NavigationHelper::class],
+            ['zendviewhelpernavigation'],
+        ];
+    }
 
-        $replacedMenuClass = 'Zend\View\Helper\Navigation\Links';
+    /**
+     * @dataProvider navigationServiceNameProvider
+     */
+    public function testConfigureServiceManagerWithConfig($navigationHelperServiceName)
+    {
+        $replacedMenuClass = NavigationHelper\Links::class;
 
-        $serviceManager = new ServiceManager([
+        $serviceManager = new ServiceManager();
+        (new Config([
             'services' => [
                 'config' => [
                     'navigation_helpers' => [
@@ -67,11 +81,12 @@ class HelperConfigTest extends TestCase
                     return new HelperPluginManager($services);
                 },
             ],
-        ]);
-        $helpers = $serviceManager->get('ViewHelperManager');
-        $helpers = (new HelperConfig())->configureServiceManager($helpers);
+        ]))->configureServiceManager($serviceManager);
 
-        $menu = $helpers->get('Navigation')->findHelper('menu');
+        $helpers = $serviceManager->get('ViewHelperManager');
+        (new HelperConfig())->configureServiceManager($helpers);
+
+        $menu = $helpers->get($navigationHelperServiceName)->findHelper('menu');
         $this->assertInstanceOf($replacedMenuClass, $menu);
     }
 }


### PR DESCRIPTION
This patch reverts some of the changes from #5 in favor of making the component forwards compatible with v3. Specifically:

- Updates dependencies to known-stable, forwards compatible versions where possible, with the following specific changes:
  - Updated zend-stdlib to `^2.7 || ^3.0`
  - Updated zend-servicemanager to `^2.7.5 || ^3.0.3`
  - Removed zend-modulemanager (not used)
- Updates the test matrix to specify the version of zend-servicemanager to use, and to test each version against each PHP version in the matrix. For tests against the zend-servicemanager v3 series, zend-mvc is removed from the dependencies.
- Updates all factory implementations to use the v2 interfaces (in v3, these inherit from the new interfaces).
- Updates all factory implementations implement the v2-specific methods (these proxy to the v3 methods).
- Simplifies test setup in the `ServiceFactory` significantly, and reverts v3-specific zend-servicemanager setup to use setup compatible with both versions.

Additionally, this patch updates the `Zend\Navigation\View\HelperConfig` class to ensure it works correctly against both v2 and v3 releases of zend-servicemanager. In particular, it adds testing to the class, which uncovered an interesting situation: the documented `navigation_helpers` configuration previously did not work! With this patch, it now works correctly, regardless of version.