### PR TITLE
Re-enable zend-mvc tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ cache:
 env:
   global:
     - SERVICE_MANAGER_VERSION="^3.0.3"
-    - REMOVE_DEPENDENCIES="zendframework/zend-mvc"
 
 matrix:
   fast_finish: true
@@ -25,24 +24,20 @@ matrix:
     - php: 5.5
       env:
         - SERVICE_MANAGER_VERSION="^2.7.5"
-        - REMOVE_DEPENDENCIES=""
     - php: 5.6
       env:
         - EXECUTE_TEST_COVERALLS=true
     - php: 5.6
       env:
         - SERVICE_MANAGER_VERSION="^2.7.5"
-        - REMOVE_DEPENDENCIES=""
     - php: 7
     - php: 7
       env:
         - SERVICE_MANAGER_VERSION="^2.7.5"
-        - REMOVE_DEPENDENCIES=""
     - php: hhvm 
     - php: hhvm 
       env:
         - SERVICE_MANAGER_VERSION="^2.7.5"
-        - REMOVE_DEPENDENCIES=""
   allow_failures:
     - php: hhvm
 
@@ -55,7 +50,6 @@ before_install:
   - composer self-update
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
   - composer require --dev --no-update "zendframework/zend-servicemanager:$SERVICE_MANAGER_VERSION"
-  - if [[ $REMOVE_DEPENDENCIES != '' ]]; then composer remove --dev --no-update $REMOVE_DEPENDENCIES ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "zendframework/zend-http": "^2.5.4",
         "zendframework/zend-i18n": "^2.6",
         "zendframework/zend-log": "^2.7.1",
-        "zendframework/zend-mvc": "^2.6.3",
+        "zendframework/zend-mvc": "^2.7",
         "zendframework/zend-permissions-acl": "^2.6",
         "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
         "zendframework/zend-uri": "^2.5",

--- a/test/Page/MvcTest.php
+++ b/test/Page/MvcTest.php
@@ -30,13 +30,6 @@ class MvcTest extends TestCase
 {
     protected function setUp()
     {
-        if (! class_exists(RouteMatch::class)) {
-            $this->markTestSkipped(
-                'Skipping zend-mvc-related tests until that component is updated '
-                . 'to zend-servicemanager v3'
-            );
-        }
-
         $this->route  = new RegexRoute(
             '((?<controller>[^/]+)(/(?<action>[^/]+))?)',
             '/%controller%/%action%',

--- a/test/ServiceFactoryTest.php
+++ b/test/ServiceFactoryTest.php
@@ -39,13 +39,6 @@ class ServiceFactoryTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        if (! class_exists(Application::class)) {
-            $this->markTestSkipped(
-                'Skipping zend-mvc-related tests until that component is updated '
-                . 'to be forwards-compatible with zend-servicemanager v3'
-            );
-        }
-
         $config = [
             'navigation' => [
                 'file'    => __DIR__ . '/_files/navigation.xml',


### PR DESCRIPTION
Since zend-mvc has a known-stable, forwards-compatible release, we can re-enable tests against it on Travis.