### PR TITLE
PHP 7.2 support, drop HHVM - update Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,20 +10,12 @@ branches:
 cache:
   directories:
     - $HOME/.composer/cache
-    - vendor
-    - $HOME/.local
-    - zf-mkdoc-theme
 
 env:
   global:
     - COMPOSER_ARGS="--no-interaction"
     - COVERAGE_DEPS="satooshi/php-coveralls"
     - LEGACY_DEPS="phpunit/phpunit"
-    - SITE_URL: https://zendframework.github.io/zend-navigation
-    - GH_USER_NAME: "Matthew Weier O'Phinney"
-    - GH_USER_EMAIL: matthew@weierophinney.net
-    - GH_REF: github.com/zendframework/zend-navigation.git
-    - secure: "tgcIcU0H/502W94XsyOA/aBb26CfaFJklEm4TZC/foM0qcoSB+U5PLmn+UtBFbuXBDApC2H/G6F+hpR1nTIp9aO9cizfpRB7GYPHJ4gq3crSgBMv5sMB0TJekypbEChoPAhxM+UT3imlA6kbw2ttcqvSqU3EcvyeIT5Ef8B4FDBPBDH6ozewUcYNoxHx1pcJnIkKdkZu9RedIt46GJ4TiJiImCS7txxPZOeNVHZpCMps/1gQEPdD6P/etvxjYrFLtnFyIdpTHB6DBnxbBlM9eYrUlUE47xW25m3gbCERNk0gBTaSXImEkk9mjnSwC1ek0SmEhaeLKxcl7o06C4sU5Evua9uUSFHBa17lGTMCJnKZ+YxIT31n/cX5vi+pcMxO2YBSXB/QiXJvhlxNtn6TqsEMYzJqOedX+t+7mexFsKLEOOut3HrjQV2ZxnTv+xnYWq+MrPlIcQhLMUTXHlAMf91el6bu1yF62I9dGTF0j252pZqGbNIst0i9Dfvd0I28f4AUDU2+YiuCuoAC9W1ISXPWd/b43gFsMSIuAFg0e3UT64CTQlUHIMHZWPVQ37TMcPmmg10RBM7jtrZPD74cJjlEilXbCNBZaDJUAQXTw51SetrqB/GfyZ9LKeHqsnd2zxXck1RiBVskwsZrveULnFS6pp9Z4j7etxrB8wSK48k="
 
 matrix:
   include:
@@ -33,8 +25,6 @@ matrix:
     - php: 5.6
       env:
         - DEPS=locked
-        - DEPLOY_DOCS="$(if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then echo -n 'true' ; else echo -n 'false' ; fi)"
-        - PATH="$HOME/.local/bin:$PATH"
     - php: 5.6
       env:
         - DEPS=latest
@@ -88,10 +78,6 @@ install:
 script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then composer test-coverage ; else composer test ; fi
   - if [[ $CS_CHECK == 'true' ]]; then composer cs-check ; fi
-  - if [[ $DEPLOY_DOCS == "true" && "$TRAVIS_TEST_RESULT" == "0" ]]; then wget -O theme-installer.sh "https://raw.githubusercontent.com/zendframework/zf-mkdoc-theme/master/theme-installer.sh" ; chmod 755 theme-installer.sh ; ./theme-installer.sh ; fi
-
-after_success:
-  - if [[ $DEPLOY_DOCS == "true" ]]; then echo "Preparing to build and deploy documentation" ; ./zf-mkdoc-theme/deploy.sh ; echo "Completed deploying documentation" ; fi
 
 after_script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then composer upload-coverage ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,17 +48,17 @@ matrix:
     - php: 7.1
       env:
         - DEPS=latest
-    - php: hhvm
+    - php: 7.2
       env:
         - DEPS=lowest
-    - php: hhvm
+    - php: 7.2
       env:
         - DEPS=locked
-    - php: hhvm
+    - php: 7.2
       env:
         - DEPS=latest
   allow_failures:
-    - php: hhvm
+    - php: 7.2
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,6 @@ matrix:
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
-  - travis_retry composer self-update
 
 install:
   - travis_retry composer install $COMPOSER_ARGS --ignore-platform-reqs

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ env:
   global:
     - COMPOSER_ARGS="--no-interaction"
     - COVERAGE_DEPS="php-coveralls/php-coveralls"
-    - LEGACY_DEPS="phpunit/phpunit"
 
 matrix:
   include:
@@ -25,6 +24,7 @@ matrix:
     - php: 5.6
       env:
         - DEPS=locked
+        - LEGACY_DEPS="phpunit/phpunit"
     - php: 5.6
       env:
         - DEPS=latest
@@ -34,6 +34,7 @@ matrix:
     - php: 7
       env:
         - DEPS=locked
+        - LEGACY_DEPS="phpunit/phpunit"
     - php: 7
       env:
         - DEPS=latest
@@ -66,7 +67,7 @@ before_install:
 
 install:
   - travis_retry composer install $COMPOSER_ARGS --ignore-platform-reqs
-  - if [[ $TRAVIS_PHP_VERSION =~ ^5.6 ]]; then travis_retry composer update $COMPOSER_ARGS --with-dependencies $LEGACY_DEPS ; fi
+  - if [[ $LEGACY_DEPS != "" ]]; then travis_retry composer update $COMPOSER_ARGS --with-dependencies $LEGACY_DEPS ; fi
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
   - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $COVERAGE_DEPS ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,14 +38,14 @@ matrix:
     - php: 7
       env:
         - DEPS=latest
-        - CS_CHECK=true
-        - TEST_COVERAGE=true
     - php: 7.1
       env:
         - DEPS=lowest
     - php: 7.1
       env:
         - DEPS=locked
+        - CS_CHECK=true
+        - TEST_COVERAGE=true
     - php: 7.1
       env:
         - DEPS=latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ matrix:
     - php: 7
       env:
         - DEPS=latest
+        - CS_CHECK=true
         - TEST_COVERAGE=true
     - php: 7.1
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,8 +58,6 @@ matrix:
     - php: 7.2
       env:
         - DEPS=latest
-  allow_failures:
-    - php: 7.2
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,10 +59,6 @@ matrix:
   allow_failures:
     - php: hhvm
 
-notifications:
-  irc: "irc.freenode.org#zftalk.dev"
-  email: false
-
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - travis_retry composer self-update
@@ -81,3 +77,6 @@ script:
 
 after_script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then composer upload-coverage ; fi
+
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ install:
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
   - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $COVERAGE_DEPS ; fi
-  - composer show
+  - stty cols 120 && composer show
 
 script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then composer test-coverage ; else composer test ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ cache:
 env:
   global:
     - COMPOSER_ARGS="--no-interaction"
-    - COVERAGE_DEPS="satooshi/php-coveralls"
+    - COVERAGE_DEPS="php-coveralls/php-coveralls"
     - LEGACY_DEPS="phpunit/phpunit"
 
 matrix:
@@ -77,7 +77,7 @@ script:
   - if [[ $CS_CHECK == 'true' ]]; then composer cs-check ; fi
 
 after_script:
-  - if [[ $TEST_COVERAGE == 'true' ]]; then composer upload-coverage ; fi
+  - if [[ $TEST_COVERAGE == 'true' ]]; then vendor/bin/php-coveralls -v ; fi
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@ sudo: false
 
 language: php
 
-branches:
-  except:
-    - /^release-.*$/
-    - /^ghgfk-.*$/
-
 cache:
   directories:
     - $HOME/.composer/cache
@@ -75,7 +70,7 @@ script:
   - if [[ $CS_CHECK == 'true' ]]; then composer cs-check ; fi
 
 after_script:
-  - if [[ $TEST_COVERAGE == 'true' ]]; then vendor/bin/php-coveralls -v ; fi
+  - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry php vendor/bin/php-coveralls -v ; fi
 
 notifications:
   email: false

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,6 @@
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",
         "test": "phpunit --colors=always",
-        "test-coverage": "phpunit --colors=always --coverage-clover clover.xml",
-        "upload-coverage": "coveralls -v"
+        "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
     }
 }


### PR DESCRIPTION
- [x] drops HHVM
- [x] adds PHP 7.2
- [x] adds missing cs checks
- [x] removes docs build (handled now by zendframework/zf-bot)
- [x] removes IRC notifications (no longer used)
- [x] sets composer column width to 120 chars
- [x] updated php-coveralls (version 2 has php-coveralls script)

Please note that develop !== master right now:
**develop is 36 commits ahead master**
https://github.com/zendframework/zend-navigation/compare/develop
