### PR TITLE
Compatibility of legacy SM2 style in PHP 7.2.

### DIFF
--- a/src/Service/AbstractNavigationFactory.php
+++ b/src/Service/AbstractNavigationFactory.php
@@ -53,10 +53,9 @@ abstract class AbstractNavigationFactory implements FactoryInterface
      * @param null|string $requestedName
      * @return Navigation
      */
-    public function createService(ServiceLocatorInterface $container, $name = null, $requestedName = null)
+    public function createService(ServiceLocatorInterface $container)
     {
-        $requestedName = $requestedName ?: Navigation::class;
-        return $this($container, $requestedName);
+        return $this($container, Navigation::class);
     }
 
     /**


### PR DESCRIPTION
Fix #69. No need to dynamically request service name, when its known that Navigation::class is one ultimately being requested in __invoke

Test will not run against 7.2 because #59 is against dev, while that branch is probably tested against SM3 making this less relevant. Although, test for general creation ability can be ported to improve coverage.